### PR TITLE
Change return type of user remove

### DIFF
--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -36,7 +36,7 @@ export interface IQuery {
 export interface IMutation {
     createUser(createUserInput: CreateUserInput): User | Promise<User>;
     updateUser(updateUserInput: UpdateUserInput): User | Promise<User>;
-    removeUser(id: string): Nullable<boolean> | Promise<Nullable<boolean>>;
+    removeUser(id: string): Nullable<string> | Promise<Nullable<string>>;
 }
 
 type Nullable<T> = T | null;

--- a/src/users/users.graphql
+++ b/src/users/users.graphql
@@ -26,5 +26,5 @@ type Query {
 type Mutation {
   createUser(createUserInput: CreateUserInput!): User!
   updateUser(updateUserInput: UpdateUserInput!): User!
-  removeUser(id: String!): Boolean
+  removeUser(id: String!): String
 }

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -137,14 +137,15 @@ describe('UsersService', () => {
     };
 
     it('should delete a user', async () => {
+      mockUserRepository.findOne.mockReturnValue(user);
       mockUserRepository.remove.mockReturnValue(user);
 
       const deleted = await service.remove(user.id);
-      expect(deleted).toBe(true);
+      expect(deleted).toBe(user.id);
     });
 
     it('should fail to delete a user', async () => {
-      jest.spyOn(service, 'findOne').mockResolvedValue(null);
+      jest.spyOn(service, 'findOne').mockRejectedValue(new NotFoundException());
 
       try {
         await service.remove(user.id);

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -40,10 +40,10 @@ export class UsersService {
     return this.usersRepository.save(merged);
   }
 
-  async remove(id: string) {
+  async remove(id: string): Promise<string> {
     const user = await this.findOne(id);
 
     this.usersRepository.remove(user);
-    return true;
+    return user.id;
   }
 }


### PR DESCRIPTION
- Change return type of remove from boolean to string
- Now removeUser returns the id of the removed user
- Updated unit tests to reflect change